### PR TITLE
External link update

### DIFF
--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,6 +1,6 @@
 Dependency Management
 =====================
 
-1. We use [dep](github.com/golang/dep).
+1. We use [dep](https://github.com/golang/dep).
 1. Any issues we have with `dep` we vow to try and resolve through participation in the `dep` project.
 1. We use `dep ensure` + `dep prune` until the two become one.

--- a/errors/README.md
+++ b/errors/README.md
@@ -34,4 +34,4 @@ return errors.New("always in lower-case")
 
 ## Third Party Tools
 
-- [pkg/errors](github.com/pkg/errors) - Dave Cheney's error handling primitives package
+- [pkg/errors](https://github.com/pkg/errors) - Dave Cheney's error handling primitives package

--- a/testing/README.md
+++ b/testing/README.md
@@ -16,7 +16,7 @@ Testing in Go
 
 ## Unit Testing
 
-Most practical ideas have been stolen from Mitchell Hashimoto's very comprehensive talk on advanced testing in Go [video](1).
+Most practical ideas have been stolen from Mitchell Hashimoto's very comprehensive talk on advanced testing in Go [video][1].
 
 ### Tests must be written before code reaches master
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -100,4 +100,4 @@ If you are dealing with a big pesky interface, it is recommended that you use so
 
 > TODO: Here we will reach out to existing Go projects and fill out this section with what others are doing well.
 
-[1]:[https://www.youtube.com/watch?v=yszygk1cpEc]
+[1]: https://www.youtube.com/watch?v=yszygk1cpEc


### PR DESCRIPTION
1. The link to `dep` and `pkg/errors` were relative url. Updated it to use absolute url.
2. Updated the youtube video link reference of Mitchell Hashimoto's talk. The reference was made in wrong markdown format.